### PR TITLE
added a bullet point about engaging with users

### DIFF
--- a/index.md
+++ b/index.md
@@ -83,7 +83,7 @@ Otherwise, you will want to simply publish the data as a raw download to avoid t
 
 You've published your data - congrats! You are enabling new, awesome ways to think. But how do you get people interested in it, and using it?
 
-**Engage with your users.** Publishing your data is the start of a conversation with your users. Make sure it's easy for them to know where they can get in touch, ask questions, and share what they are doing with it. Whether it's an email address, a discussion list, a web forum, or an issue tracker put effort into shaping the conversations that happen there.
+**Engage with your users.** Publishing your data is the start of a conversation with your users. Make sure it's easy for them to know where they can get in touch, ask questions, and share what they are doing with your data. Whether you use an email address, a discussion list, a web forum, or an issue tracker put effort into shaping the conversations that happen there.
 
 **Find your peers and talk.** Now that you're working in the open, you'll find that other folks are doing similar stuff - the state over from yours has the same kind of dataset. Talk to them, link to them, and figure out how you can learn from one another.
 


### PR DESCRIPTION
I felt like a teensy bit more could be said about making it clear where to ask questions (and have conversations) about published data. It felt like it was somewhat similar to the _Find your peers and talk_ section, but really it's kind of different.
