### PR TITLE
Corrected name and URL

### DIFF
--- a/more.md
+++ b/more.md
@@ -13,5 +13,5 @@ Want more details about some part of open data? Here are some great resources:
 * [Creative Commons](http://creativecommons.org/) has produced tested, well-explained
   licenses for creative works and data.
 
-Still have questions? [The Open Data Institute](http://theodi.org/)
+Still have questions? [The U.S. Open Data Institute](http://usodi.org/)
 provides free guidance: [contact@usodi.org](mailto:contact@usodi.org) / <a href='tel:202-719-5315'>202-719-5315</a>


### PR DESCRIPTION
The ODI is a UK organization, the US ODI is a U.S. organization. (We share a charter, with the UK organization as a sort of a parent for other ODI "nodes.")
